### PR TITLE
changes to twostage_results

### DIFF
--- a/R/twostage_results.R
+++ b/R/twostage_results.R
@@ -110,8 +110,34 @@ twostage_results <- function(csv = FALSE,
     stop("'primary_objectives' must be a vector with element 'eff_target'")
   }
 
-  # Elizabeth I deleted all of the NULL assignments here. It seems to me like
-  # we don't need them, but I may be wrong?
+  scenario <- NULL
+  dose_num <- NULL
+  true_dlt_prob <- NULL
+  true_eff_prob <- NULL
+  type <- NULL
+  is_acceptable <- NULL
+  design <- NULL
+  array_id <- NULL
+  sim_id <- NULL
+  RP2DCode <- NULL
+  RP2DAcceptable <- NULL
+  key <- NULL
+  value <- NULL
+  RP2DCode_truth <- NULL
+  set_designation <- NULL
+  design_label <- NULL
+  bestP2D <- NULL
+  sum_n <- NULL
+  prop_n <- NULL
+  prob <- NULL
+  is_acceptable_by_dose_num <- NULL
+  text_height <- NULL
+  n_total_enrolled <- NULL
+  mean_patients <- NULL
+  ataccept <- NULL
+  total <- NULL
+  atRP2D <- NULL
+  prop_acc <- NULL
 
   text_size = 4;
   legend_text_size = 7;


### PR DESCRIPTION
Summary of changes:
- changed finaldatfolder to patientdatfolder, line 84 
- expanded the error message to include the case that a bad path is passed, line 160
- modified the code that reads in results to be a little speedier, lines 232-249
- dropped the des_lab variable and just used design_labels because it seemed unnecessary , line 327
- modified the code that creates designnum and scennum to be what I felt was more readable, line 336-347
- added clarity to the dose_outcomes_curve (now dose_outcomes_curve_list) argument
- added the creation of the dose-distribution-over-patient-number plot, which we present in the paper
- deleted a bunch of null assignments that I think we can drop
- changed matrices/data.frame to tibbles
- changed gathers to pivot_longers, spreads to pivot_widers

Other comments: Elizabeth I changed something else on line 76, which I think is created by Roxygen. I made this change because ggplot2 was throwing a warning that expand_scale is deprecated in favor of expansion. So I replaced each instance of expand_scale to expansion, but I'm not sure if I'm allowed to just replace the importfrom line this way or if Roxygen needs to do its magic. 